### PR TITLE
version pinning bug

### DIFF
--- a/metrics.py
+++ b/metrics.py
@@ -145,12 +145,13 @@ def get_pinned(repo: str) -> str:
         total = 1
         num = 1
         if "dependencies" in parse:
+            total += 1
             for i in parse["dependencies"]:
                 if re.search(r"\d\.[1-9]\d*\.", parse["dependencies"][i]):
                     num += 1
             if num > 0:
-                total /= num
-            return str(total)
+                num /= total
+            return str(num)
         else:
             return "1"
     else:


### PR DESCRIPTION
I realized I misunderstood the version pinning calculation as I reviewed the code. I think it's fixed now. I thought it wanted the fraction of pinned dependencies over 1 but instead, it wanted the fraction of pinned version dependencies over total dependencies. I think it's fixed now 